### PR TITLE
Fix(acompanhamento): Make client filter comparison robust

### DIFF
--- a/js/acompanhamento.js
+++ b/js/acompanhamento.js
@@ -408,8 +408,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       );
     }
     if (filtroCliente.value) {
+      const clienteSelecionado = filtroCliente.value.trim();
       ordensFiltradas = ordensFiltradas.filter(
-        (ordem) => ordem.cliente === filtroCliente.value
+        (ordem) => ordem.cliente && ordem.cliente.trim() === clienteSelecionado
       );
     }
     if (filtroNOS.value) {


### PR DESCRIPTION
The client filter on the order tracking page was failing because it used a strict `===` comparison. This would fail if there were any differences in whitespace between the client name in the dropdown and the client name in the order data.

This change makes the comparison robust by:
1. Trimming whitespace from both the selected filter value and the order's client property before comparison.
2. Ensuring the order's client property exists before attempting to trim it.