### PR TITLE
Fix(acompanhamento): Make client filter comparison robust

### DIFF
--- a/js/acompanhamento.js
+++ b/js/acompanhamento.js
@@ -408,9 +408,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       );
     }
     if (filtroCliente.value) {
-      const clienteSelecionado = filtroCliente.value.trim();
+      const clienteSelecionado = filtroCliente.value.trim().toLowerCase();
       ordensFiltradas = ordensFiltradas.filter(
-        (ordem) => ordem.cliente && ordem.cliente.trim() === clienteSelecionado
+        (ordem) => ordem.cliente && ordem.cliente.trim().toLowerCase() === clienteSelecionado
       );
     }
     if (filtroNOS.value) {


### PR DESCRIPTION
The client filter on the order tracking page was failing because it used a strict `===` comparison. This would fail if there were any differences in whitespace or character case between the client name in the dropdown and the client name in the order data.

This change makes the comparison robust by:
1. Trimming whitespace from both the selected filter value and the order's client property.
2. Converting both strings to lowercase for a case-insensitive comparison.
3. Ensuring the order's client property exists before attempting to normalize it.