### PR TITLE
Fix: Use correct API endpoint for loading service order details

### DIFF
--- a/js/editar_os_module_isolado.js
+++ b/js/editar_os_module_isolado.js
@@ -44,7 +44,7 @@
     // Função para CARREGAR os dados da OS (mantendo a lógica original de carregamento)
     async function getOrdemDetalhadaParaCarregamento(ordemId) {
         try {
-            const response = await fetch(`${API_BASE_URL}/api/gerenciamento_isolado/ordens/${ordemId}`);
+            const response = await fetch(`${API_BASE_URL}/api/edicao_os_dedicada/ordens/${ordemId}`);
             if (!response.ok) {
                 if (response.status === 404) {
                     throw new Error("Ordem não encontrada para este ID (carregamento original)");


### PR DESCRIPTION
The `getOrdemDetalhadaParaCarregamento` function in the isolated edit module was calling an incorrect API endpoint (`/api/gerenciamento_isolado/ordens/:id`), which was returning an HTML error page instead of JSON data. This caused a JSON parsing error and prevented the service order details from loading.

This commit updates the endpoint to `/api/edicao_os_dedicada/ordens/:id`, which is the correct, dedicated endpoint for both fetching and updating service order data in the isolated edit view. This aligns the GET request with the existing PUT request and resolves the error.