### PR TITLE
Fix(edit-os): Correct API endpoint in editar_os_module_isolado

### DIFF
--- a/js/editar_os_module_isolado.js
+++ b/js/editar_os_module_isolado.js
@@ -44,7 +44,7 @@
     // Função para CARREGAR os dados da OS (mantendo a lógica original de carregamento)
     async function getOrdemDetalhadaParaCarregamento(ordemId) {
         try {
-            const response = await fetch(`${API_BASE_URL}/api/gerenciamento_isolado/ordens/${ordemId}`);
+            const response = await fetch(`${API_BASE_URL}/api/gerenciamento/ordens/${ordemId}`);
             if (!response.ok) {
                 if (response.status === 404) {
                     throw new Error("Ordem não encontrada para este ID (carregamento original)");


### PR DESCRIPTION
The function to load order details on the isolated edit page was calling an incorrect API endpoint (`/api/gerenciamento_isolado/...`), which resulted in the server returning an HTML error page instead of the expected JSON data.

This caused a `SyntaxError: ... is not valid JSON` on the page.

This commit corrects the URL to the proper endpoint (`/api/gerenciamento/...`), ensuring the frontend can successfully fetch and parse the order details.