### PR TITLE
Fix(api): Use correct endpoint for loading service order details

### DIFF
--- a/js/editar_os_module_isolado.js
+++ b/js/editar_os_module_isolado.js
@@ -44,7 +44,7 @@
     // Função para CARREGAR os dados da OS (mantendo a lógica original de carregamento)
     async function getOrdemDetalhadaParaCarregamento(ordemId) {
         try {
-            const response = await fetch(`${API_BASE_URL}/api/gerenciamento/ordens/${ordemId}`);
+            const response = await fetch(`${API_BASE_URL}/ordem-servico/${ordemId}`);
             if (!response.ok) {
                 if (response.status === 404) {
                     throw new Error("Ordem não encontrada para este ID (carregamento original)");


### PR DESCRIPTION
The `getOrdemDetalhadaParaCarregamento` function in the isolated edit module was calling a non-functional API endpoint, which returned an HTML error page instead of JSON data. This caused a `SyntaxError` on the frontend and prevented service order details from loading.

This commit updates the failing endpoint to use the `/ordem-servico/:id` path. This path is used elsewhere in the application (`js/services.js`) to fetch single order details and is the most likely candidate to be the correct, functional endpoint.

This is a targeted fix that only changes the data loading function that was causing the error, leaving the data saving function untouched to avoid introducing new bugs, as recommended by a code review.