### PR TITLE
fix: Correct API URL for production environment

### DIFF
--- a/js/editar_os_module_isolado.js
+++ b/js/editar_os_module_isolado.js
@@ -8,7 +8,7 @@
 
     const API_BASE_URL = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1' 
         ? 'http://localhost:3000' 
-        : '';
+        : 'https://us-central1-os---perfecta.cloudfunctions.net';
 
     const mostrarMensagemEditarIsolado = (mensagem, tipo = 'info') => {
         let mensagemElement = document.getElementById('isolated-mensagem-sistema');


### PR DESCRIPTION
The API_BASE_URL was not set for the production environment, causing API calls to fail with a JSON parsing error. This change sets the correct API URL for production, ensuring that API calls are sent to the correct endpoint.