### PR TITLE
fix: Correct API endpoint for fetching order details

### DIFF
--- a/js/editar_os_module_isolado.js
+++ b/js/editar_os_module_isolado.js
@@ -44,7 +44,7 @@
     // Função para CARREGAR os dados da OS (mantendo a lógica original de carregamento)
     async function getOrdemDetalhadaParaCarregamento(ordemId) {
         try {
-            const response = await fetch(`${API_BASE_URL}/api/gerenciamento_isolado/ordens/${ordemId}`);
+            const response = await fetch(`${API_BASE_URL}/api/edicao_os_dedicada/ordens/${ordemId}`);
             if (!response.ok) {
                 if (response.status === 404) {
                     throw new Error("Ordem não encontrada para este ID (carregamento original)");


### PR DESCRIPTION
The previous endpoint for fetching order details was incorrect, resulting in a 404 error. This change updates the endpoint to the correct path, `/api/edicao_os_dedicada/ordens/`, which is the same one used for updating the order. This ensures that the application can successfully fetch order details for editing.