### PR TITLE
This commit addresses two separate issues:

### DIFF
--- a/js/gerenciamento.js
+++ b/js/gerenciamento.js
@@ -144,10 +144,13 @@ async function carregarOrdensGerenciamento(filtros = {}) {
     const corpoTabelaOrdens = document.getElementById("corpoTabelaOrdens");
     corpoTabelaOrdens.innerHTML = '<tr><td colspan="9" style="text-align: center;">Carregando ordens...</td></tr>';
     try {
-        // A função getOrdensGerenciamento em services.js precisará ser ajustada
-        // para lidar com um array de status, se o backend esperar isso.
-        // Por enquanto, vamos assumir que o backend pode receber um array ou que services.js o tratará.
-        const ordens = await getOrdensGerenciamento(filtros); 
+        let ordens;
+        // Se não houver filtros, busca todas as OS. Se houver, usa a busca com filtro.
+        if (Object.keys(filtros).length === 0) {
+            ordens = await getOrdens(); // Função que busca todas as ordens
+        } else {
+            ordens = await getOrdensGerenciamento(filtros); // Função que busca com filtros
+        }
         console.log("Ordens recebidas:", ordens);
         renderizarTabelaGerenciamento(ordens); // Renomeado para clareza
     } catch (error) {


### PR DESCRIPTION
1.  **Schedule Page Duplication:** The work schedule page (`programacao.html`) was occasionally displaying duplicate work orders. This was caused by a redundant, un-referenced script (`js/programacao.js`) that contained duplicate logic. This script has been removed to prevent race conditions and resolve the bug. The page now correctly relies only on `js/agendatrabalho.js`.

2.  **Management Page Incomplete Data:** The management page (`gerenciamento.html`) was not displaying all service orders on its initial load. This was because it was calling a backend endpoint that returned a filtered view by default. The logic in `js/gerenciamento.js` has been updated to call a different function (`getOrdens()`) when no filters are applied, ensuring all service orders are fetched and displayed initially. The filtering functionality remains intact when the user applies filters.