### PR TITLE
fix: Correct API endpoints for client and location fetching

### DIFF
--- a/js/editar_os_module_isolado.js
+++ b/js/editar_os_module_isolado.js
@@ -63,7 +63,8 @@
 
     async function getClientesIsolado() {
         try {
-            const response = await fetch(`${API_BASE_URL}/clientes_isolado`);
+            // CORREÇÃO: Removido o sufixo _isolado da rota, que não existe.
+            const response = await fetch(`${API_BASE_URL}/clientes`);
             if (!response.ok) throw new Error('Erro ao buscar clientes');
             return await response.json();
         } catch (error) {
@@ -75,7 +76,8 @@
 
     async function getLocaisPorClienteIsolado(clienteId) {
         try {
-            const response = await fetch(`${API_BASE_URL}/locais_isolado/cliente/${clienteId}`);
+            // CORREÇÃO: Removido o sufixo _isolado da rota, que não existe.
+            const response = await fetch(`${API_BASE_URL}/locais/cliente/${clienteId}`);
             if (!response.ok) throw new Error('Erro ao buscar locais do cliente');
             return await response.json();
         } catch (error) {


### PR DESCRIPTION
This commit fixes a 404 Not Found error that occurred when loading the client list on the isolated 'Edit Service Order' page.

- Corrected the fetch URLs in `getClientesIsolado` and `getLocaisPorClienteIsolado` functions within `js/editar_os_module_isolado.js`.
- The incorrect `_isolado` suffix was removed from the API paths, ensuring the application calls the correct endpoints (`/clientes` and `/locais/cliente/:clienteId`).

This fix is applied on top of the feature implementation that allows editing the client and their details.